### PR TITLE
issue#2 : get API key from user input via Discord

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,21 +15,40 @@ async def on_ready():
 @client.event
 async def on_message(message):
     sendmsg = "👀"
+    sendchannel = message.channel
     # ignore messages from the bot itself
     print(message.content)
     if message.author == client.user:
         return
     if "?" in message.content:
         sendmsg = "The universe is under no obligation to make sense to you."
+        await message.channel.send(sendmsg)
     elif "space" in message.content:
         if not api_key:
-            sendmsg = "I'd have loved to show you a really awesome space image right about now but alas you didn't pass any API key. You can pass one using the `-k` or the `--key` flag."
+            sendmsg = "I'd have loved to show you a really awesome space image right about now but alas you didn't pass any API key. You can pass one using the `-k` or the `--key` flag. Or, you can send the API key to me through DM."
+            await message.channel.send(sendmsg)
+            @client.event
+            async def on_message(message):
+            	if message.author == client.user:
+            		return
+            	if isinstance(message.channel, discord.channel.DMChannel):
+            		sendmsg = "Thanks, got the API key through DM. Here is your image."
+            		await sendchannel.send(sendmsg)
+            		api_key1 = message.content
+            		url = f"https://api.nasa.gov/planetary/apod?api_key={api_key1}"
+            		resp = requests.get(url)
+            		data = json.loads(resp.text)
+            		imgurl = data['hdurl']
+            		sendmsg = imgurl
+            		await sendchannel.send(sendmsg)
         else:
             url = f"https://api.nasa.gov/planetary/apod?api_key={api_key}"
             resp = requests.get(url)
             data = json.loads(resp.text)
             imgurl = data['hdurl']
             sendmsg = imgurl
-    await message.channel.send(sendmsg)
+            await message.channel.send(sendmsg)
+    else:
+    	await message.channel.send(sendmsg)
 
 client.run(bot_key)


### PR DESCRIPTION
This pull request updates the main.py file and makes necessary changes so that if the user forgets to pass the NASA API key as a flag while running the server, he won't have to restart the bot altogether again rather he can DM the bot with the API key and the bot will be able to show the image in the main discord channel.